### PR TITLE
fix(EA-455): fix algolia client timeout

### DIFF
--- a/modules/update_customer_dispo/update_customer_dispo.bal
+++ b/modules/update_customer_dispo/update_customer_dispo.bal
@@ -108,7 +108,7 @@ class CustomerDispoJob {
     }
 
     function scheduledRun() returns error? {
-        http:Client algoliaClient = check new (self.algoliaUrl);
+        http:Client algoliaClient = check new (self.algoliaUrl, {timeout: 180});
 
         foreach string indexName in self.algolia.indexNames {
             string? lastRun = check getLastRunTimestamp(indexName);


### PR DESCRIPTION
- from test feedback, adds a 180s timeout theshold to the algolia client: a random error from the algolia browse requests : "Error occurred while retrieving the json payload from the response", seems to occur less, and maybe no more, with such a threshold value.