### PR TITLE
feat(EA-456): fix requests retry

### DIFF
--- a/modules/algolia/algolia_index.bal
+++ b/modules/algolia/algolia_index.bal
@@ -198,9 +198,10 @@ class AlgoliaIndexJob {
             retryConfig: {
                 interval: 5, // délai en secondes entre 2 tentatives
                 count: 4, // nombre d’essais total max (incluant donc la tentative initiale)
-                backOffFactor: 2.0 // backoff exponentiel qui multiplie le délai à chaque tentative, donc 5s pour la 1ere, puis 2x5s pour la seonde, puis 2x2X5s pour la 3eme
+                backOffFactor: 2.0, // backoff exponentiel qui multiplie le délai à chaque tentative, donc 5s pour la 1ere, puis 2x5s pour la seonde, puis 2x2X5s pour la 3eme
+                statusCodes: [400, 500, 502, 503, 504] // codes qui déclenchent le retry
             },
-            failoverCodes: [400, 500, 502, 503, 504], // codes qui déclenchent failover, pas le retry
+            failoverCodes: [400, 500, 502, 503, 504], // codes qui déclenchent le failover
             interval: 3, // délai entre 2 endpoints si failover
             targets: [
                 {url: "https://" + conf.appId + "-dsn.algolia.net"},
@@ -210,6 +211,7 @@ class AlgoliaIndexJob {
             ]
         });
     }
+
 
     function addCalculatedFields(db:Offre|db:Loyer 'record) {
 


### PR DESCRIPTION
-  adds 400 as a retry statusCode, as it is in fact possible to define explicitely retry codes , (this was not done in the previous config because an IA told it was not possible to define explicitely those codes...)
- NB:  define such code(s) ovveride the default retried code set managed silently by this ballerina http module, yet ballerina litterature does not provide the codes in this default set, but litterature talks about 5xx codes as the default codes...