### PR TITLE
fix(EA-465): indexation: excludes time slot

### DIFF
--- a/java_bindings/README.md
+++ b/java_bindings/README.md
@@ -7,7 +7,15 @@ Ce composant a été créé pour le ticket EA-442:
 bal bindgen java.time.LocalDateTime
 
 ```
-* puis l'utiliser: voir un exemple dans main.bal.
+* puis l'utiliser: voir un exemple dans main.bal;
+* pourallerina.toml:
+```
+[[package.modules]]
+name = "java_bindings.java.time"
+export = true
+
+```
+
 
 
 ### Déploiement et configuration

--- a/modules/algolia/Dependencies.toml
+++ b/modules/algolia/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.5"
+version = "2.14.6"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -373,10 +373,22 @@ dependencies = [
 	{org = "ballerinai", name = "observe"},
 	{org = "cosmobilis", name = "job_patch"},
 	{org = "cosmobilis", name = "postgres_db"},
-	{org = "cosmobilis", name = "teams"}
+	{org = "cosmobilis", name = "teams"},
+	{org = "cosmobilis", name = "time"}
 ]
 modules = [
 	{org = "cosmobilis", packageName = "algolia", moduleName = "algolia"}
+]
+
+[[package]]
+org = "cosmobilis"
+name = "java_bindings"
+version = "0.1.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "time"},
+	{org = "ballerinai", name = "observe"}
 ]
 
 [[package]]
@@ -417,5 +429,19 @@ dependencies = [
 ]
 modules = [
 	{org = "cosmobilis", packageName = "teams", moduleName = "teams"}
+]
+
+[[package]]
+org = "cosmobilis"
+name = "time"
+version = "0.1.0"
+dependencies = [
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "time"},
+	{org = "ballerinai", name = "observe"},
+	{org = "cosmobilis", name = "java_bindings"}
+]
+modules = [
+	{org = "cosmobilis", packageName = "time", moduleName = "time"}
 ]
 

--- a/modules/algolia/README.md
+++ b/modules/algolia/README.md
@@ -19,6 +19,13 @@ apiKey = "REPLACEME"
 indexNames = {"offres": "dev_ELITE_OFFERS", "loyers": "dev_ELITE_LOYERS"}
 ## indexNames = {"offres": "prod_ELITE_OFFERS", "loyers": "prod_ELITE_LOYERS"}
 
+[conf.schedule]
+# job execution frequency interval in seconds
+interval = 900.0
+# job execution is cancelled during this time slot:
+# [<time slot start hour>, <time slot start minute>, <time slot start second>, <time slot end hour>, <time slot end minute>, <time slot end second>]
+excludedTimeSlot = [0,0,0,1,30,0]
+
 # switch the proper option depending on the target env: dev/preprod: true, prod: false
 dryRun = true
 ## dryRun = false

--- a/modules/time/main.bal
+++ b/modules/time/main.bal
@@ -1,0 +1,13 @@
+import ballerina/log;
+
+public function main() returns error? {
+
+    //between time slot test/example
+    TimeSlot timeSlot = [11,25,0,11,30,0];  
+    if (between(timeSlot))  {
+        log:printInfo("now is between time slot: " + timeSlot.toString());
+    } else {
+        log:printInfo("now is NOT between time slot: " + timeSlot.toString());
+    }
+
+}

--- a/modules/time/time.bal
+++ b/modules/time/time.bal
@@ -2,6 +2,9 @@ import ballerina/log;
 import ballerina/time;
 import cosmobilis/java_bindings.java.time as j_time;
 
+//TimeSlot has six int values: hours start, minutes start, seconds start, hours end, minutes end, seconds end
+public type TimeSlot int[6];
+
 // s'il est 16:00:00 au moment de l'exécution de cette fonction et que l'heure passée en paramètre est 15:00:00,
 // la fonction retourne la date civile de demain 15:00:00 sinon celle d'aujourd'hui 15:00:00.
 // cette date est donnée dans la time zone configurée au niveau de l'OS executant cette fonction.
@@ -30,4 +33,11 @@ public function at(int hours, int minutes, int seconds) returns time:Civil|error
     log:printDebug(`civil time schedule:
     ${civilSchedule.toString()}`);
     return civilSchedule;
+}
+
+public function between(TimeSlot timeSlot, j_time:ZonedDateTime theTime = j_time:ZonedDateTime_now()) returns boolean {
+    j_time:ZonedDateTime startTime = theTime.withHour(timeSlot[0]).withMinute(timeSlot[1]).withSecond(timeSlot[2]);
+    j_time:ZonedDateTime endTime = theTime.withHour(timeSlot[3]).withMinute(timeSlot[4]).withSecond(timeSlot[5]);
+
+    return (theTime.toEpochSecond() >= startTime.toEpochSecond() && theTime.toEpochSecond() <= endTime.toEpochSecond());
 }


### PR DESCRIPTION
-  adds conf to cancel algolia indexation job during a configurable time slot, see tkt for more context;
-  manages also indexation job frequency in a new conf variable;
- adds main to test cosmobilis time  library;
- misc:
  - fix missing conf info in some README;